### PR TITLE
Fix compiler error on uncasted objc_msgSend calls in Xcode 6.2

### DIFF
--- a/Pod/Classes/HRSErrorRecoveryAttempter.m
+++ b/Pod/Classes/HRSErrorRecoveryAttempter.m
@@ -95,7 +95,7 @@
 	// method signature:
 	// - (void)didPresentErrorWithRecovery:(BOOL)didRecover contextInfo:(void *)contextInfo;
 	BOOL didRecover = [self attemptRecoveryFromError:error optionIndex:recoveryOptionIndex];
-	objc_msgSend(delegate, didRecoverSelector, didRecover, contextInfo);
+	((void (*)(id delegate, SEL selector, BOOL didRecover, void *contextInfo))objc_msgSend)(delegate, didRecoverSelector, didRecover, contextInfo);
 }
 
 @end


### PR DESCRIPTION
This fixes a compiler error in Xcode 6.2 by casting `objc_msgSend` calls, as stated in the comments of `objc/message.h`

    /* Basic Messaging Primitives
     *
     * On some architectures, use objc_msgSend_stret for some struct return types.
     * On some architectures, use objc_msgSend_fpret for some float return types.
     * On some architectures, use objc_msgSend_fp2ret for some float return types.
     *
     * These functions must be cast to an appropriate function pointer type 
     * before being called. 
     */
    #if !OBJC_OLD_DISPATCH_PROTOTYPES
    OBJC_EXPORT void objc_msgSend(void /* id self, SEL op, ... */ )
        __OSX_AVAILABLE_STARTING(__MAC_10_0, __IPHONE_2_0);
    OBJC_EXPORT void objc_msgSendSuper(void /* struct objc_super *super, SEL op, ... */ )
        __OSX_AVAILABLE_STARTING(__MAC_10_0, __IPHONE_2_0);
    #else