### PR TITLE
Fixed issue when importing into Swift CocoaPod

### DIFF
--- a/Pod/Classes/HRSCustomErrorHandling.h
+++ b/Pod/Classes/HRSCustomErrorHandling.h
@@ -12,7 +12,7 @@
 //	limitations under the License.
 //
 
-#import <HRSCustomErrorHandling/UIResponder+HRSCustomErrorPresentation.h>
-#import <HRSCustomErrorHandling/HRSErrorCoalescingQueue.h>
-#import <HRSCustomErrorHandling/HRSErrorPresenter.h>
-#import <HRSCustomErrorHandling/HRSErrorRecoveryAttempter.h>
+#import "UIResponder+HRSCustomErrorPresentation.h"
+#import "HRSErrorCoalescingQueue.h"
+#import "HRSErrorPresenter.h"
+#import "HRSErrorRecoveryAttempter.h"


### PR DESCRIPTION
Fixed issue "Include of non-modular header inside framework module 'H…RSCustomErrorHandling.HRSCustomErrorHandling'" when importing HRSCustomErrorHandling into a Swift CocoaPod