### PR TITLE
fix: presenter queue blocked if presenting error without recovery attempter

### DIFF
--- a/Pod/Classes/Private/HRSErrorPresenterDelegate.m
+++ b/Pod/Classes/Private/HRSErrorPresenterDelegate.m
@@ -43,6 +43,14 @@
 - (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
 {
 	id recoveryAttempter = [self.error recoveryAttempter];
+	if (!recoveryAttempter) {
+		// No recovery handler present. Call completion handler without success
+		// to fulfill the guarantee that the completion handler will always be
+		// called
+		self.completionHandler(NO);
+		return;
+	}
+
 	// alert view button indexes are ordered oposite to the error options index!
 	NSInteger optionIndex = alertView.numberOfButtons - buttonIndex - 1;
 	BOOL didRecover = [recoveryAttempter attemptRecoveryFromError:self.error optionIndex:optionIndex];


### PR DESCRIPTION
## Bug description

If an error without a recovery handler is presented, a default OK button is added. However, pressing it leaves `recoveryAttempter` in `[HRSErrorPresenterDelegate alertView:clickedButtonAtIndex:]` `nil` and no completion handler is called. Thus `presenting` of `HRSErrorCoalescingQueue` is stuck at `YES` and no more errors can be displayed until the app is killed.

## Fix

If there is no recovery handler, simply call the completion handler as if recovery failed.